### PR TITLE
fix(select/telescope): check for nil selection

### DIFF
--- a/lua/dressing/select/telescope.lua
+++ b/lua/dressing/select/telescope.lua
@@ -37,6 +37,7 @@ M.select = function(config, items, opts, on_choice)
         actions._close(prompt_bufnr, false)
         if not selection then
           -- User did not select anything.
+          on_choice(nil, nil)
           return
         end
         local idx = nil

--- a/lua/dressing/select/telescope.lua
+++ b/lua/dressing/select/telescope.lua
@@ -35,6 +35,10 @@ M.select = function(config, items, opts, on_choice)
       actions.select_default:replace(function()
         local selection = state.get_selected_entry()
         actions._close(prompt_bufnr, false)
+        if not selection then
+          -- User did not select anything.
+          return
+        end
         local idx = nil
         for i, item in ipairs(items) do
           if item == selection.value then


### PR DESCRIPTION
Hello, thanks for this great plugin! I've been running into some nil access errors when not selecting anything from the telescope menu (for example, [when searching for an entry that doesn't exist so that it clears the results, and then press enter](https://asciinema.org/a/kCM12JgpsuK3ysYAaqNaTvJF2)). Figured that doing a simple check would make sense here