### PR TITLE
fix(telescope): allow passing theme options to select

### DIFF
--- a/lua/dressing/select/telescope.lua
+++ b/lua/dressing/select/telescope.lua
@@ -4,6 +4,8 @@ M.is_supported = function()
   return pcall(require, "telescope")
 end
 
+local defaults = { previewer = false }
+
 M.select = function(config, items, opts, on_choice)
   local themes = require("telescope.themes")
   local actions = require("telescope.actions")
@@ -21,9 +23,10 @@ M.select = function(config, items, opts, on_choice)
     }
   end
 
-  local picker_opts = themes[string.format("get_%s", config.theme)]({
-    previewer = false,
-  })
+  local picker_opts = type(config.theme) == "table"
+    and vim.tbl_extend("force", config.theme, defaults)
+    or themes[string.format("get_%s", config.theme)](defaults)
+
   pickers.new(picker_opts, {
     prompt_title = opts.prompt,
     finder = finders.new_table({


### PR DESCRIPTION
This PR adds the ability for a user to specify the options they would like to add to the telescope picker. Currently, a user can only choose a theme as a string but cannot determine things like the width, height, border characters etc. This PR adds the ability for a user to pass the theme object *or a string* to dressing to have that be used by telescope.

e.g.
```lua
use {'dressing.nvim', config = function()
	config = function()
        require('dressing').setup {
          select = {
            winblend = 2,
            telescope = {
              theme = require('telescope.themes').get_cursor { -- or 'cursor'
				border_chars = {chars_i_like},
                layout_config = {
                  height = function(self, _, max_lines)
                    return random_height_i_computed
                  end,
                },
              },
            },
          },
        }
      end
```

This is similar to how https://github.com/nvim-telescope/telescope-ui-select.nvim works, tbh I'm not actually sure passing `{ previewer = false }` is necessary since that plugin doesn't bother to do that and it doesn't try and create a preview 🤷🏿 