### PR TITLE
Exit on <C-c> only when insert_only is true

### DIFF
--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -265,12 +265,13 @@ setmetatable(M, {
     local keyopts = { silent = true, noremap = true }
     local close_rhs = "<cmd>lua require('dressing.input').close()<CR>"
     vim.api.nvim_buf_set_keymap(bufnr, "n", "<Esc>", close_rhs, keyopts)
+    vim.api.nvim_buf_set_keymap(bufnr, "n", "<C-c>", close_rhs, keyopts)
     if config.insert_only then
       vim.api.nvim_buf_set_keymap(bufnr, "i", "<Esc>", close_rhs, keyopts)
+      vim.api.nvim_buf_set_keymap(bufnr, "i", "<C-c>", close_rhs, keyopts)
     end
 
     local confirm_rhs = "<cmd>lua require('dressing.input').confirm()<CR>"
-    vim.api.nvim_buf_set_keymap(bufnr, "i", "<C-c>", close_rhs, keyopts)
     vim.api.nvim_buf_set_keymap(bufnr, "i", "<CR>", confirm_rhs, keyopts)
     vim.api.nvim_buf_set_keymap(bufnr, "n", "<CR>", confirm_rhs, keyopts)
     vim.api.nvim_buf_set_keymap(


### PR DESCRIPTION
Hi, thanks for a great plugin! I just started using it and I like it a lot.

The only thing bothering me is that I use `<C-c>` instead of `<Esc>` normally to exit insert mode. With this plugin, I tend to close the `input` window when I really want to enter normal mode. This change treats `<C-c>` the same as `<Esc>`.

## Context
☝️ 

## Description

Map `<C-c>` the same as `<Esc>` for `input,` including when `insert_only` is enabled.

## Test Plan
None.