### PR TITLE
Use fzf#wrap to respect user option

### DIFF
--- a/autoload/dressing.vim
+++ b/autoload/dressing.vim
@@ -1,10 +1,10 @@
 function! dressing#fzf_run(labels, options, window) abort
-	call fzf#run({
+	call fzf#run(fzf#wrap({
         \ 'source': a:labels,
         \ 'sink': funcref('dressing#fzf_choice'),
         \ 'options': a:options,
         \ 'window': a:window,
-        \ })
+        \}))
 endfunction
 
 function! dressing#fzf_choice(label) abort


### PR DESCRIPTION
`fzf.vim` provides both `fzf#run` and `fzf#wrap`. The latter function is used to force `fzf#run` to respect user options defined in e.g. `g:fzf_layout`. I believe it is better to use this so that dressings fzf behaviour respects user options.

See `:help fzf#wrap` for more details.