### PR TITLE
feat: trim trailing colon from prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ require('dressing').setup({
     -- Priority list of preferred vim.select implementations
     backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui" },
 
+    -- Trim trailing `:` from prompt
+    trim_prompt = true,
+
     -- Options for telescope selector
     -- These are passed into the telescope picker directly. Can be used like:
     -- telescope = require('telescope.themes').get_ivy({...})

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -47,6 +47,9 @@ local default_config = {
     -- Priority list of preferred vim.select implementations
     backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui" },
 
+    -- Trim trailing `:` from prompt
+    trim_prompt = true,
+
     -- Options for telescope selector
     -- These are passed into the telescope picker directly. Can be used like:
     -- telescope = require('telescope.themes').get_ivy({...})

--- a/lua/dressing/select/init.lua
+++ b/lua/dressing/select/init.lua
@@ -36,6 +36,10 @@ return vim.schedule_wrap(function(items, opts, on_choice)
   end
 
   opts.prompt = opts.prompt or "Select one of:"
+  if config.trim_prompt and opts.prompt:sub(-1, -1) == ":" then
+    opts.prompt = opts.prompt:sub(1, -2)
+  end
+
   local format_override = config.format_item_override[opts.kind]
   if format_override then
     opts.format_item = format_override


### PR DESCRIPTION
_2 sentence summary of change_

`vim.ui.select` prompts may have a trailing semicolon which some users may want to remove from floating window displays. This allows them to remove it :D

## Context

_What is the problem you are trying to solve?_

_If related to an issue, please link it here. You may omit some background
details if it is in the issue._

There may be an unnecessary trailing colon from `vim.ui.select` prompts when using floating displays.

## Description

_Describe how the changes add the functionality or fix the issue under "Context"_

User can specify whether to automatically trim this trailing colon from select prompts.

## Test Plan

_list the steps you took to test this functionality. Steps should be
reproducible by others._

Adjusting config value `trim_prompt` with different backends in tests/manual/select.lua (adding a trailing colon to the prompt in line 8).