### PR TITLE
fix(select): use original vim.ui.select if enabled is false

### DIFF
--- a/lua/dressing/select/init.lua
+++ b/lua/dressing/select/init.lua
@@ -32,7 +32,7 @@ return vim.schedule_wrap(function(items, opts, on_choice)
   local config = global_config.get_mod_config("select", opts)
 
   if not config.enabled then
-    return patch.original_mods.input(items, opts, on_choice)
+    return patch.original_mods.select(items, opts, on_choice)
   end
 
   opts.prompt = opts.prompt or "Select one of:"


### PR DESCRIPTION
Looks like a copy-paste typo. Introduced in 31f12fff6e71a14ddce30bfc7ec9b29a2137ccde.
