### PR TITLE
Add start_in_insert option

### DIFF
--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -12,6 +12,9 @@ local default_config = {
     -- When true, <Esc> will close the modal
     insert_only = true,
 
+    -- When true, input will start in insert mode.
+    start_in_insert = true,
+
     -- These are passed to nvim_open_win
     anchor = "SW",
     border = "rounded",

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -333,7 +333,9 @@ setmetatable(M, {
       aug END
     ]])
 
-    vim.cmd("startinsert!")
+    if config.start_in_insert then
+      vim.cmd("startinsert!")
+    end
     close_completion_window()
     M.highlight()
   end),

--- a/tests/input_spec.lua
+++ b/tests/input_spec.lua
@@ -78,6 +78,28 @@ a.describe("input modal", function()
     assert(ret == "my text", string.format("Got '%s' expected 'my text'", ret))
   end)
 
+  a.it("starts in normal mode when start_in_insert = false", function()
+    local orig_cmd = vim.cmd
+    local startinsert_called = false
+    vim.cmd = function(cmd)
+      if cmd == "startinsert!" then
+        startinsert_called = true
+      end
+      orig_cmd(cmd)
+    end
+
+    require("dressing.config").input.start_in_insert = false
+    run_input({
+      "my text",
+      "<CR>",
+    }, {
+      after_fn = function()
+        vim.cmd = orig_cmd
+      end,
+    })
+    assert(not startinsert_called, "Got 'true' expected 'false'")
+  end)
+
   a.it("cancels first callback if second input is opened", function()
     local tx, rx = channel.oneshot()
     vim.ui.input({}, tx)


### PR DESCRIPTION
Add a new option, `start_in_insert`, that defaults to true and controls whether the input will start in insert or normal mode.

## Context

I'd like to conditionally enable normal mode when certain criteria are met, e.g. when using `vim.ui.input` with LSP rename.

## Description

This PR introduces an option that controls whether insert mode will be activated or not, and it can be used along with `get_config` for conditional behavior. For instance:

```lua
require('dressing').setup({
  input = {
    ...
    get_config = function(opts)
      return {
        start_in_insert = #(opts.default or '') == 0,
      }
    end,
  }
})

```

## Test Plan

Test case 1
- Set `start_in_insert` to `true` in `setup()` (or leave it unset since the default value is true already).
- Run `vim.ui.input({default = "some text"}, function() end)`.
- An input window should open in insert mode.

Test case 2
- Set `start_in_insert` to `false` in `setup()`
- Run `vim.ui.input({default = "some text"}, function() end)`.
- An input window should open in normal mode.
