### PR TITLE
fix: error on first fzf-lua run

### DIFF
--- a/lua/dressing/select/fzf_lua.lua
+++ b/lua/dressing/select/fzf_lua.lua
@@ -5,7 +5,7 @@ M.is_supported = function()
 end
 
 M.select = function(config, items, opts, on_choice)
-  local fzf = require("fzf-lua")
+  local fzf = require("fzf-lua.core")
   local labels = {}
   for i, item in ipairs(items) do
     table.insert(labels, string.format("%d: %s", i, opts.format_item(item)))


### PR DESCRIPTION
Fix fzf_lua backend error

## Context

The error popup:

```
Error executing vim.schedule lua callback: ...cker/start/dressing.nvim/lua/dressing/select/fzf_lua.lua:30: attempt to call a nil value
stack traceback:
        ...cker/start/dressing.nvim/lua/dressing/select/fzf_lua.lua:30: in function 'select'
        .../packer/start/dressing.nvim/lua/dressing/select/init.lua:63: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

## Description

Since fzf_lua is lazily loading the api on any built-in command execution, we need explicitly load fzf-lua.core module to exercise the api directly, without relying on lazy loading.

## Test Plan

The issue discovered  on ziontee113/icon-picker.nvim with basic packer configuration:

```lua
use({
    "ziontee113/icon-picker.nvim",
    requires = { "stevearc/dressing.nvim" },
    config = config.icon_picker,
  })
  ...
  M.icon_picker = function()
  require("icon-picker").setup({})
end
  ```
  
  1. Setup ziontee113/icon-picker.nvim
  2. Restart neovim
  3. Run `:IconPickerInsert` from neovim command prompt.
  

