### PR TITLE
fix issue when operating from a floating window

### DIFF
--- a/lua/dressing/select/init.lua
+++ b/lua/dressing/select/init.lua
@@ -65,7 +65,9 @@ return vim.schedule_wrap(function(items, opts, on_choice)
     items,
     opts,
     vim.schedule_wrap(function(...)
-      vim.api.nvim_win_set_cursor(winid, cursor)
+      if vim.api.nvim_win_is_valid(winid) then
+        vim.api.nvim_win_set_cursor(winid, cursor)
+      end
       on_choice(...)
     end)
   )


### PR DESCRIPTION
the floating window would get closed when we open and returning to the original window would crash.


## Context

_What is the problem you are trying to solve?_

Very concretely, I enabled the floating window mode of nvim-tree. When doing that, triggering a file deletion from nvim-tree will call vim.ui.select, which will trigger dressing. Dressing opens a window to confirm the deletion, _closing the nvim-tree floating window_. When confirming the deletion, dressing attempts to return focus to nvim-tree, but that fails since nvim-tree was closed.

## Description

When returning focus to the original window, check whether that one still exists

## Test Plan

See context.
