### PR TITLE
fix(fzf-lua): pass prompt option to fzf

### DIFF
--- a/lua/dressing/select/fzf_lua.lua
+++ b/lua/dressing/select/fzf_lua.lua
@@ -11,7 +11,10 @@ M.select = function(config, items, opts, on_choice)
     table.insert(labels, string.format("%d: %s", i, opts.format_item(item)))
   end
 
+  local prompt = (opts.prompt or "Select one of") .. "> "
+
   local fzf_opts = vim.tbl_deep_extend("keep", config, {
+    prompt = prompt,
     fzf_opts = {
       ["--no-multi"] = "",
       ["--preview-window"] = "hidden:right:0",


### PR DESCRIPTION
Pass the `prompt` value given to `vim.ui.select` to [fzf-lua](https://github.com/ibhagwan/fzf-lua)

## Context

Currently the select ui never shows any prompt for fzf-lua

See this example which should show the prompt "Code actions"

![image](https://user-images.githubusercontent.com/6849129/202634737-ce05c103-3ec1-4d04-a8c6-17277e79d584.png)

This is what I would expect (and how it looks with my changes):

![image](https://user-images.githubusercontent.com/6849129/202635026-e2b14613-9503-443a-9bec-0944a61ca67c.png)

## Description

Check for a given prompt value in the `opts` parameter, otherwise fall back to "Select one of" (as `vim.ui.select` does by default). Instead of using a colon fzf usually uses the `>` as a delimiter for the prompt which is why I did so as well.
