### PR TITLE
feat: allow to pass extra opts to vim.keymap.set()

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ require('dressing').setup({
     mappings = {
       n = {
         ["<Esc>"] = "Close",
+        -- You can also pass additional opts to vim.keymap.set().
+        -- ["<Esc>"] = { "Close", nowait = true },
         ["<CR>"] = "Confirm",
       },
       i = {

--- a/doc/dressing.txt
+++ b/doc/dressing.txt
@@ -48,6 +48,8 @@ Configure dressing.nvim by calling the setup() function.
         mappings = {
           n = {
             ["<Esc>"] = "Close",
+            -- You can also pass additional opts to vim.keymap.set().
+            -- ["<Esc>"] = { "Close", nowait = true },
             ["<CR>"] = "Confirm",
           },
           i = {

--- a/lua/dressing/map_util.lua
+++ b/lua/dressing/map_util.lua
@@ -8,7 +8,7 @@ end
 
 ---@param bufnr number
 ---@param mode string
----@param bindings table<string, string>
+---@param bindings table<string, string|table>
 ---@param prefix string
 M.create_maps_to_plug = function(bufnr, mode, bindings, prefix)
   local maps
@@ -17,6 +17,16 @@ M.create_maps_to_plug = function(bufnr, mode, bindings, prefix)
   end
   for lhs, rhs in pairs(bindings) do
     if rhs then
+      local opts = { buffer = bufnr, remap = true }
+      if type(rhs) == "table" then
+        for k, v in pairs(rhs) do
+          if type(k) == "string" then
+            opts[k] = v
+          elseif k == 1 then
+            rhs = v
+          end
+        end
+      end
       -- Prefix with <Plug> unless this is a <Cmd> or :Cmd mapping
       if type(rhs) == "string" and not rhs:match("[<:]") then
         rhs = "<Plug>" .. prefix .. rhs
@@ -30,7 +40,7 @@ M.create_maps_to_plug = function(bufnr, mode, bindings, prefix)
           end
         end
       end
-      vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, remap = true })
+      vim.keymap.set(mode, lhs, rhs, opts)
     end
   end
 end


### PR DESCRIPTION
Allow additional opts to be passed to vim.keymap.set().

## Context

I want to pass `{ nowait = true }`.

## Description

Allow additional opts to be passed to vim.keymap.set().

## Test Plan

Define an nmap that begins with `<Esc>` as follows, and pass `{ nowait = true }` to see if the delay exists.

`nnoremap <Esc><Esc> <Cmd>nohl<CR>`
