### PR TITLE
Do not display item number for fzf_lua

### DIFF
--- a/lua/dressing/select/fzf_lua.lua
+++ b/lua/dressing/select/fzf_lua.lua
@@ -7,8 +7,8 @@ end
 M.select = function(config, items, opts, on_choice)
   local fzf = require("fzf-lua")
   local labels = {}
-  for i, item in ipairs(items) do
-    table.insert(labels, string.format("%d: %s", i, opts.format_item(item)))
+  for _, item in ipairs(items) do
+    table.insert(labels, string.format("%s", opts.format_item(item)))
   end
 
   local prompt = (opts.prompt or "Select one of") .. "> "


### PR DESCRIPTION
I struggled to disable the item numbers until I found out it was from dressing and not fzf_lua that defines behavior. It should be consistent with the other backends which do not display the item number. If the user wishes so, it is easy to do in the select function.

_2 sentence summary of change_

## Context

_What is the problem you are trying to solve?_

_If related to an issue, please link it here. You may omit some background
details if it is in the issue._

## Description

_Describe how the changes add the functionality or fix the issue under "Context"_

## Test Plan

_list the steps you took to test this functionality. Steps should be
reproducible by others._
