### PR TITLE
ci: add release-please to automate semantic versioning releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,27 @@ jobs:
       - name: Run tests
         run: |
           bash ./run_tests.sh
+
+  release:
+    name: release
+
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs:
+      - luacheck
+      - stylua
+      - run_tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: simple
+          package-name: dressing.nvim
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-create-tag@v1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          tag: stable
+          message: "Current stable release: ${{ steps.release.outputs.tag_name }}"
+          tag_exists_error: false
+          force_push_tag: true


### PR DESCRIPTION
This adds the release please github action for making release PRs to automate the release process and add semantic versioning tracking to Dressing! It automatically calculates the next version based on conventional commit messages which you are following :)

## Context

It is nice to have semantic versioning so users who use a plugin manager that can utilize that information can be let know when there are breaking changes easily and also set up the plugin managers to not update to the next major version to not accept breaking changes until they have time to handle the changes.

## Description

This adds the [release-please](https://github.com/google-github-actions/release-please-action) GitHub action which automatically calculates version numbers based on conventional commit messages and creates release PRs that can then be easily merged in when you are ready to tag the next release. It also handles managing changelogs and release notes in those releases as well.
