### PR TITLE
docs: fix winhighlight example

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,9 @@ for more details. Example:
 ```lua
 require('dressing').setup({
   input = {
-    winhighlight = 'NormalFloat:DiagnosticError'
+    win_options = {
+      winhighlight = 'NormalFloat:DiagnosticError'
+    }
   }
 })
 ```


### PR DESCRIPTION
Corrects the example in the `README` about how to use `winhiglight` for customizing highlights.

## Context

Follow-up of #101.
