### PR TITLE
fix: plugin keymaps delayed

### DIFF
--- a/lua/dressing/map_util.lua
+++ b/lua/dressing/map_util.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.create_plug_maps = function(bufnr, plug_bindings)
   for _, binding in ipairs(plug_bindings) do
-    vim.keymap.set("", binding.plug, binding.rhs, { buffer = bufnr, desc = binding.desc })
+    vim.keymap.set("", binding.plug, binding.rhs, { buffer = bufnr, desc = binding.desc, nowait = true })
   end
 end
 
@@ -17,7 +17,7 @@ M.create_maps_to_plug = function(bufnr, mode, bindings, prefix)
   end
   for lhs, rhs in pairs(bindings) do
     if rhs then
-      local opts = { buffer = bufnr, remap = true }
+      local opts = { buffer = bufnr, remap = true, nowait = true }
       if type(rhs) == "table" then
         for k, v in pairs(rhs) do
           if type(k) == "string" then


### PR DESCRIPTION
Remove delay when using a plugin keymap.

## Context

_What is the problem you are trying to solve?_
When you have a keymap like `qq`, and then also set `q` as a keymap to close Dressing, the result is a minor delay due to nvim waiting to see whether you are going for `q` or `qq`.

## Description

_Describe how the changes add the functionality or fix the issue under "Context"_
They add `nowait = true`, which has the purpose of removing the delay in such cases.

## Test Plan

_list the steps you took to test this functionality. Steps should be
reproducible by others._
Use a keymap for `qq` and set 
```lua
				mappings = { n = { ["q"] = "Close" } },
```
