### PR TITLE
fix(map_util): insert bindings for <Plug>, <Cmd> and :Cmd work

### DIFF
--- a/lua/dressing/map_util.lua
+++ b/lua/dressing/map_util.lua
@@ -35,7 +35,9 @@ M.create_maps_to_plug = function(bufnr, mode, bindings, prefix)
       -- Prefix with <Plug> unless this is a <Cmd> or :Cmd mapping
       if type(rhs) == "string" then
         if not rhs:match("[<:]") then
-          rhs = "<Plug>" .. prefix .. rhs
+          rhs = "<Plug>" .. prefix .. rhs .. "<CR>"
+        else
+          rhs = rhs .. "<CR>"
         end
         if mode == "i" then
           rhs = "<C-o>" .. rhs

--- a/lua/dressing/map_util.lua
+++ b/lua/dressing/map_util.lua
@@ -33,18 +33,15 @@ M.create_maps_to_plug = function(bufnr, mode, bindings, prefix)
         end
       end
       -- Prefix with <Plug> unless this is a <Cmd> or :Cmd mapping
-      if type(rhs) == "string" and not rhs:match("[<:]") then
-        rhs = "<Plug>" .. prefix .. rhs
-      end
-      if mode == "i" then
-        -- HACK for some reason I can't get plug mappings to work in insert mode
-        for _, map in ipairs(maps) do
-          if map.lhs == rhs then
-            rhs = map.callback or map.rhs
-            break
-          end
+      if type(rhs) == "string" then
+        if not rhs:match("[<:]") then
+          rhs = "<Plug>" .. prefix .. rhs
+        end
+        if mode == "i" then
+          rhs = "<C-o>" .. rhs
         end
       end
+
       ---@cast rhs string
       vim.keymap.set(mode, lhs, rhs, opts)
     end


### PR DESCRIPTION
Fix the `map_util.create_maps_to_plug` function to work with `<Plug>`, `<Cmd>` and `:Cmd`.
A future change could also insert `<CR>` after `<Cmd>` and `:Cmd`.

## Context

I shamelessly stole the `map_util.lua` file for a project of my own (I'll figure out licensing if I release it).
But I noticed that for insert mode bindings it would insert `<Plug>NameOf:Command` into the buffer instead of executing it.

<details><summary>Demo:</summary>

https://github.com/stevearc/dressing.nvim/assets/8889986/f435229d-0aac-4b35-8ba6-1d2feb09b704

</details>

## Description

I was able to fix the bug by just putting a `<C-o>` in front of the command in insert mode.

<details><summary>Demo:</summary>

https://github.com/stevearc/dressing.nvim/assets/8889986/dc6ad2de-8e5d-45d1-bb87-700f020646c3

</details>
