### PR TITLE
feat: add `trim_prompt` setting for `vim.ui.input`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ require("dressing").setup({
     enabled = true,
 
     -- Default prompt string
-    default_prompt = "Input:",
+    default_prompt = "Input",
+
+    -- Trim trailing `:` from prompt
+    trim_prompt = true,
 
     -- Can be 'left', 'right', or 'center'
     title_pos = "left",

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -4,7 +4,10 @@ local default_config = {
     enabled = true,
 
     -- Default prompt string
-    default_prompt = "Input:",
+    default_prompt = "Input",
+
+    -- Trim trailing `:` from prompt
+    trim_prompt = true,
 
     -- Can be 'left', 'right', or 'center'
     title_pos = "left",

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -251,6 +251,17 @@ local function get_max_strwidth(lines)
   return max
 end
 
+---@param title string
+---@param trim_colon boolean input.trim_prompt config
+---@return string
+local function trim_and_pad_title(title, trim_colon)
+  title = vim.trim(title)
+  if trim_colon then
+    title = title:gsub(":$", "")
+  end
+  return (" %s "):format(title)
+end
+
 ---@param config table
 ---@param prompt_lines string[]
 ---@param default? string
@@ -308,7 +319,7 @@ local function create_or_update_win(config, prompt_lines, default)
     end
   end
   if vim.fn.has("nvim-0.9") == 1 and #prompt_lines == 1 then
-    winopt.title = prompt_lines[1]:gsub("^%s*(.-)%s*$", " %1 ")
+    winopt.title = trim_and_pad_title(prompt_lines[1], config.trim_prompt)
     -- We used to use "prompt_align" here
     winopt.title_pos = config.prompt_align or config.title_pos
   end
@@ -440,7 +451,7 @@ local function show_input(opts, on_confirm)
   if vim.fn.has("nvim-0.9") == 0 and #prompt_lines == 1 then
     util.add_title_to_win(
       winid,
-      string.gsub(prompt_lines[1], "^%s*(.-)%s*$", "%1"),
+      trim_and_pad_title(prompt_lines[1], config.trim_prompt),
       { align = config.prompt_align }
     )
   end


### PR DESCRIPTION
Give `input` the same `trim_prompt` setting `select` already has.

## Context

_What is the problem you are trying to solve?_  
It's really only a minor aesthetic improvement. Also makes `input` and `select` more consistent, as they both now have a `trim_prompt` setting.

## Description

_Describe how the changes add the functionality or fix the issue under "Context"_
The gist of it: if `input.trim_only` then `title = title:gsub(":$", "")`.

## Test Plan

_list the steps you took to test this functionality. Steps should be
reproducible by others._

confirm that it works correctly: 
```lua
require("dressing").setup { input = { trim_prompt = true } }
vim.ui.input({ prompt = "Input: " }, function () end)
```

```lua
require("dressing").setup { input = { trim_prompt = false } }
vim.ui.input({ prompt = "Input: " }, function () end)
```
