### PR TITLE
fix: take into account prompt size in nui and builtin selects

### DIFF
--- a/lua/dressing/select/builtin.lua
+++ b/lua/dressing/select/builtin.lua
@@ -55,7 +55,7 @@ M.select = function(config, items, opts, on_choice)
   end
   local lines = {}
   local highlights = {}
-  local max_width = 1
+  local max_width = opts.prompt and vim.api.nvim_strwidth(opts.prompt) or 1
   for idx, item in ipairs(items) do
     local prefix = ""
     if config.show_numbers then

--- a/lua/dressing/select/nui.lua
+++ b/lua/dressing/select/nui.lua
@@ -8,7 +8,7 @@ M.select = function(config, items, opts, on_choice)
   local Menu = require("nui.menu")
   local event = require("nui.utils.autocmd").event
   local lines = {}
-  local line_width = 1
+  local line_width = opts.prompt and vim.api.nvim_strwidth(opts.prompt) or 1
   for i, item in ipairs(items) do
     local line = opts.format_item(item)
     line_width = math.max(line_width, vim.api.nvim_strwidth(line))


### PR DESCRIPTION
## Context

Width calculation logic in nui and builtin selects ignores prompt size. This makes it very easy to lose crucial information required to make a decision.

For example, here's what I see when running `LspStart` with the `vtsls` language server with master of `stevearc/dressing.nvim`:

<img width="351" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/8a8347fd-f1e3-45d1-a854-2bb31a363eb6">

<img width="358" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/650c619a-7c2d-43a6-9238-840d188e123d">

And here's what I see with this PR:

<img width="1182" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/e2e183cd-1a15-4b86-9c2f-9d9c4a94087d">
<img width="1188" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/604d1a69-398a-44ad-898b-34f39394e5cf">


## Description

Initialize `max_width` (builtin) or `line_width` (nui) to the prompt length if it exists. Otherwise fallback to previous value of 1.

## Test Plan

Used the manual select test with the following configuration:

```
-- Run this test with :source %

local function run_test(backend)
  local config = require("dressing.config")
  local prev_backend = config.select.backend
  config.select.backend = backend
  vim.ui.select({
    "first",
    "second",
    "third",
  }, {
    prompt = "Make a very informed selection after having collected all data and considered all viewpoints and opinions: ",
    kind = "test",
  }, function(item, lnum)
    if item and lnum then
      vim.notify(string.format("selected '%s' (idx %d)", item, lnum), vim.log.levels.INFO)
    else
      vim.notify("Selection canceled", vim.log.levels.INFO)
    end
    config.select.backend = prev_backend
  end)
end

-- Replace this with the desired backend to test
run_test("builtin")
--run_test("nui")
```

### Before

<img width="696" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/5292d037-8fcb-4f76-94c5-316dbd7e89cf">

<img width="373" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/c7f19c14-87c8-4912-ace2-41b435c0113b">

### After

<img width="905" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/3e5fcf20-9b62-41da-b2fa-6838fab891d1">

<img width="861" alt="image" src="https://github.com/stevearc/dressing.nvim/assets/373323/56684faa-f6c9-4dd1-934f-4723fee645f4">
