### PR TITLE
fix: add space after prompt to look nicer

### DIFF
--- a/lua/dressing/select/fzf.lua
+++ b/lua/dressing/select/fzf.lua
@@ -33,7 +33,7 @@ M.select = function(config, items, opts, on_choice)
     local item = items[lnum]
     on_choice(item, lnum)
   end
-  vim.fn["dressing#fzf_run"](labels, string.format('--prompt="%s"', opts.prompt), config.window)
+  vim.fn["dressing#fzf_run"](labels, string.format('--prompt="%s "', opts.prompt), config.window)
   -- fzf doesn't have a cancel callback, so we have to make one.
   vim.cmd([[autocmd TermClose <buffer> ++once lua require('dressing.select.fzf')._on_term_close()]])
 end


### PR DESCRIPTION
add space after prompt for fzf backend to look good

## Context

Using fzf as backend, without this extra space, the prompt gets mixed with the ones we are typing making it unable to read like in the below screenshot
![image](https://github.com/stevearc/dressing.nvim/assets/56352048/94d387c7-e016-4c70-bc8f-4ee47d0f41ba)
Even after disabling trim_prompts it looks like this which is little bit unclear to read
![image](https://github.com/stevearc/dressing.nvim/assets/56352048/34286c8e-9a10-4682-a247-bd2ceba64bba)

## Description

It adds an extra space to the prompt making it look cleaner and seperates the input from prompt making it readable like in the screenshot below

Without trim prompts enabled
![image](https://github.com/stevearc/dressing.nvim/assets/56352048/de34cdff-2f49-49a0-af60-debecb5ebb54)
With trim prompts enabled
![image](https://github.com/stevearc/dressing.nvim/assets/56352048/fc25f2b1-1f74-4b1d-b8b3-5c4246fc062d)


## Test Plan

```lua
bootstrap_paq({
  	{
		"junegunn/fzf",
		build = ":call fzf#install()",
	},
	"junegunn/fzf.vim",
	"nomnivore/ollama.nvim",
	"stevearc/dressing.nvim",
})

require("ollama").setup({
	model = "codellama",
	url = "http://127.0.0.1:11434",
	-- serve = {
	--	on_start = false,
	--	command = "ollama",
	--	args = { "serve" },
	--	stop_command = "pkill",
	--	stop_args = { "-SIGTERM", "ollama" },
	-- },
	prompts = {
		Sample_Prompt = {
			prompt = "This is a sample prompt that receives $input and $sel(ection), among others.",
			input_label = "> ",
			model = "codellama",
			action = "display",
		},
	},
})

require("dressing").setup({
	select = {
		backend = { "fzf", "nui", "builtin" },
		trim_prompt = false,
	},
})
```
