### PR TITLE
fix: handle extra scenario where the prompt is sent with trailing spaces

### DIFF
--- a/lua/dressing/select/init.lua
+++ b/lua/dressing/select/init.lua
@@ -52,7 +52,7 @@ local select = vim.schedule_wrap(function(items, opts, on_choice)
   end
 
   opts.prompt = sanitize_line(opts.prompt or "Select one of:")
-  opts.prompt = opts.prompt:gsub(":$", "")
+  opts.prompt = vim.trim(opts.prompt)
   if config.trim_prompt and opts.prompt:sub(-1, -1) == ":" then
     opts.prompt = opts.prompt:sub(1, -2)
   end

--- a/lua/dressing/select/init.lua
+++ b/lua/dressing/select/init.lua
@@ -52,6 +52,7 @@ local select = vim.schedule_wrap(function(items, opts, on_choice)
   end
 
   opts.prompt = sanitize_line(opts.prompt or "Select one of:")
+  opts.prompt = opts.prompt:gsub("%s+", "")
   if config.trim_prompt and opts.prompt:sub(-1, -1) == ":" then
     opts.prompt = opts.prompt:sub(1, -2)
   end

--- a/lua/dressing/select/init.lua
+++ b/lua/dressing/select/init.lua
@@ -52,7 +52,7 @@ local select = vim.schedule_wrap(function(items, opts, on_choice)
   end
 
   opts.prompt = sanitize_line(opts.prompt or "Select one of:")
-  opts.prompt = opts.prompt:gsub("%s+", "")
+  opts.prompt = opts.prompt:gsub(":$", "")
   if config.trim_prompt and opts.prompt:sub(-1, -1) == ":" then
     opts.prompt = opts.prompt:sub(1, -2)
   end


### PR DESCRIPTION
Handle extra prompt scenario where the prompt has trailing spaces leading to unwanted behaviour.

## Context
The way trim_prompt works is that if the last character is ":" it trims it. But the issue is there are plugins like nvim-dap which send prompts like this "Configurations: " with an extra trailing space leading to the addition of extra space by my last pr for fzf backend https://github.com/stevearc/dressing.nvim/pull/136 to add an unwanted extra space. This pr fixes that behaviour.

Behaviour withou this pr
![Screenshot 2024-01-18 063313](https://github.com/stevearc/dressing.nvim/assets/56352048/cb971a67-6b60-4644-97b4-c22f47784e0d)

Behaviour with this pr
![Screenshot 2024-01-18 064157](https://github.com/stevearc/dressing.nvim/assets/56352048/17566b91-22c7-4836-8396-1b2a1d1338eb)

## Description

It changes the prompts functionality by removing trailing spaces from prompts.

## Test Plan

```lua
bootstrap_paq({
  	{
		"junegunn/fzf",
		build = ":call fzf#install()",
	},
	"junegunn/fzf.vim",
	"stevearc/dressing.nvim",
	"mfussenegger/nvim-dap",
        {
		"microsoft/vscode-js-debug",
		build = function()
			local path = vim.fn.stdpath("data") .. "/site/pack/paqs/start/vscode-js-debug"
			vim.fn.system({
				"bash",
				"-c",
				"cd " .. path .. " && rm -rf dist out && npm install && npx gulp vsDebugServerBundle && mv dist out",
			})
			return true
		end,
	},
	"mxsdev/nvim-dap-vscode-js",
})

require("dap-vscode-js").setup({
	debugger_path = vim.fn.stdpath("data") .. "/site/pack/paqs/start/vscode-js-debug",
	adapters = { "pwa-node" },
})
for _, language in ipairs({ "typescript", "javascript" }) do
	require("dap").configurations[language] = {
		{
			type = "pwa-node",
			request = "launch",
			name = "Launch file",
			program = "${file}",
			cwd = "${workspaceFolder}",
		},
		{
			type = "pwa-node",
			request = "attach",
			name = "Attach",
			processId = require("dap.utils").pick_process,
			cwd = "${workspaceFolder}",
		},
	}
end


require("dressing").setup({
	select = {
		backend = { "fzf", "nui", "builtin" },
		trim_prompt = false,
	},
})
```
You can start a debug session to see the above difference.
```lua
:lua require('dap').continue()
```