### PR TITLE
feat(fzf-lua): add an input indicator after prompt

### DIFF
--- a/lua/dressing/select/fzf_lua.lua
+++ b/lua/dressing/select/fzf_lua.lua
@@ -5,6 +5,9 @@ M.is_supported = function()
 end
 
 M.select = function(config, items, opts, on_choice)
+  if opts.prompt then
+    opts.prompt = opts.prompt .. "> "
+  end
   local ui_select = require("fzf-lua.providers.ui_select")
   if config and not vim.tbl_isempty(config) then
     -- Registering then unregistering sets the config options

--- a/lua/dressing/select/fzf_lua.lua
+++ b/lua/dressing/select/fzf_lua.lua
@@ -6,7 +6,14 @@ end
 
 M.select = function(config, items, opts, on_choice)
   if opts.prompt then
-    opts.prompt = opts.prompt .. "> "
+    -- If we're not using ":" as the separator, use ">"
+    if not vim.endswith(opts.prompt, ":") then
+      opts.prompt = opts.prompt .. ">"
+    end
+    -- Ensure there is some whitespace between the prompt and input
+    if not vim.endswith(opts.prompt, " ") then
+      opts.prompt = opts.prompt .. " "
+    end
   end
   local ui_select = require("fzf-lua.providers.ui_select")
   if config and not vim.tbl_isempty(config) then


### PR DESCRIPTION
## Context

fzf_lua shows its prompt and user input in the same line and dressing.nvim tries to make prompts like the title of a window, so it causes the prompt and input to be crowded together.

![image](https://github.com/stevearc/dressing.nvim/assets/61115159/5ef5ab54-9fed-42b2-b614-f3621f6e14de)

## Description

I suggest adding a separator after the prompt.

![image](https://github.com/stevearc/dressing.nvim/assets/61115159/f1d6ded7-2115-4a79-b069-533eaafdabb2)

