### PR TITLE
fix stuck input control if callback fails

### DIFF
--- a/lua/dressing/util.lua
+++ b/lua/dressing/util.lua
@@ -200,8 +200,10 @@ M.make_queued_async_fn = function(callback_arg_num, fn)
     args[callback_arg_num] = function(...)
       local cb_args = vim.F.pack_len(...)
       vim.schedule(function()
-        cb(vim.F.unpack_len(cb_args))
+        -- first schedule the consumption, only later invoke
+        -- the callback, because the callback could fail
         vim.schedule(consume)
+        cb(vim.F.unpack_len(cb_args))
       end)
     end
     table.insert(queue, args)


### PR DESCRIPTION
before this change, with vim.ui.input, if the user callback triggers a vim error, dressing would get stuck and all following vim.ui.input invocations would hang/not be processed.

## Context

It is possible to reproduce the issue by triggering this vim command:
```
:lua vim.ui.input({prompt=hi}, function(input) vim.api.nvim_win_close(39483904, {}) end)
```
so we try to close a non-existing vim window. That will fail. But after this, trigger the same command again, and the dressing input prompt will not appear. Because the callback throwing "broke" the dressing logic.

## Description

Instead of first invoking the user callback and then scheduling the consumption, invert the order to make sure the user callback failing cannot break the dressing logic.
I considered using pcall to invoke the user callback, but if the user callback has an error, something should fail and the error should be bubbled back to the UI, which does not occur with pcall.

## Test Plan

You can run the command I gave as an example twice in row. Without the change, it'll work only the first time. With the change, it'll work twice and more.
