### PR TITLE
Add support for start_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ require("dressing").setup({
     -- Can be 'left', 'right', or 'center'
     title_pos = "left",
 
-    -- The initial mode when the window opens.
+    -- The initial mode when the window opens (insert|normal|visual|select).
     start_mode = "insert",
 
     -- These are passed to nvim_open_win

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ require("dressing").setup({
     -- Can be 'left', 'right', or 'center'
     title_pos = "left",
 
-    -- When true, input will start in insert mode.
-    start_in_insert = true,
+    -- The initial mode when the window opens.
+    start_mode = "insert",
 
     -- These are passed to nvim_open_win
     border = "rounded",

--- a/doc/dressing.txt
+++ b/doc/dressing.txt
@@ -19,7 +19,7 @@ Configure dressing.nvim by calling the setup() function.
         -- Can be 'left', 'right', or 'center'
         title_pos = "left",
 
-        -- The initial mode when the window opens.
+        -- The initial mode when the window opens (insert|normal|visual|select).
         start_mode = "insert",
 
         -- These are passed to nvim_open_win

--- a/doc/dressing.txt
+++ b/doc/dressing.txt
@@ -19,8 +19,8 @@ Configure dressing.nvim by calling the setup() function.
         -- Can be 'left', 'right', or 'center'
         title_pos = "left",
 
-        -- When true, input will start in insert mode.
-        start_in_insert = true,
+        -- The initial mode when the window opens.
+        start_mode = "insert",
 
         -- These are passed to nvim_open_win
         border = "rounded",

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -168,7 +168,6 @@ local M = vim.deepcopy(default_config)
 ---@param opts table
 ---@return table
 M.apply_shim = function(key, opts)
-
   -- Support start_in_insert for backwards compatibility.
   if key == "input" and opts.start_in_insert ~= nil then
     opts.start_mode = opts.start_in_insert and "insert" or "normal"

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -12,8 +12,8 @@ local default_config = {
     -- Can be 'left', 'right', or 'center'
     title_pos = "left",
 
-    -- When true, input will start in insert mode.
-    start_in_insert = true,
+    -- The initial mode when the window opens.
+    start_mode = "insert",
 
     -- These are passed to nvim_open_win
     border = "rounded",

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -12,7 +12,7 @@ local default_config = {
     -- Can be 'left', 'right', or 'center'
     title_pos = "left",
 
-    -- The initial mode when the window opens.
+    -- The initial mode when the window opens (insert|normal|visual|select).
     start_mode = "insert",
 
     -- These are passed to nvim_open_win

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -163,11 +163,25 @@ local default_config = {
 
 local M = vim.deepcopy(default_config)
 
+-- Apply shims for backwards compatibility
+---@param key string
+---@param opts table
+---@return table
+M.apply_shim = function(key, opts)
+
+  -- Support start_in_insert for backwards compatibility.
+  if key == "input" and opts.start_in_insert ~= nil then
+    opts.start_mode = opts.start_in_insert and "insert" or "normal"
+  end
+
+  return opts
+end
+
 M.update = function(opts)
   local newconf = vim.tbl_deep_extend("force", default_config, opts or {})
 
   for k, v in pairs(newconf) do
-    M[k] = v
+    M[k] = M.apply_shim(k, v)
   end
 end
 
@@ -177,7 +191,10 @@ M.get_mod_config = function(key, ...)
   if not M[key].get_config then
     return M[key]
   end
+
   local conf = M[key].get_config(...)
+  conf = M.apply_shim(key, conf)
+
   if conf then
     return vim.tbl_deep_extend("force", M[key], conf)
   else

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -445,7 +445,7 @@ local show_input = util.make_queued_async_fn(2, function(opts, on_confirm)
 
   local start_mode = config.start_mode
 
-  local prompt = opts.prompt or config.default_prompt
+  local prompt = opts.prompt or config.default_prompt --[[@as string]]
   local prompt_lines = vim.split(prompt, "\n", { plain = true, trimempty = true })
 
   -- Create or update the window

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -105,7 +105,7 @@ M.history_next = function()
 end
 
 ---@param mode dressing.Mode?
-local function set_mode(mode)
+M.set_mode = function(mode)
   if mode == "normal" then
     vim.cmd("stopinsert")
   elseif mode == "insert" then
@@ -113,13 +113,13 @@ local function set_mode(mode)
   elseif mode == "visual" then
     vim.api.nvim_command("normal! vg_")
   elseif mode == "select" then
-    set_mode("visual")
+    M.set_mode("visual")
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-g>", true, false, true), "n", true)
   end
 end
 
 ---@param mode dressing.Mode?
-local function restore_mode(mode)
+M.restore_mode = function(mode)
   if mode == "normal" then
     vim.cmd("stopinsert")
   end
@@ -143,7 +143,7 @@ local function confirm(text)
   close_completion_window()
   local ctx = context
   context = {}
-  restore_mode(ctx.mode_to_restore)
+  M.restore_mode(ctx.mode_to_restore)
 
   -- We have to wait briefly for the popup window to close (if present),
   -- otherwise vim gets into a very weird and bad state. I was seeing text get
@@ -524,7 +524,7 @@ local show_input = util.make_queued_async_fn(2, function(opts, on_confirm)
   })
 
   ---@cast start_mode dressing.Mode
-  set_mode(start_mode)
+  M.set_mode(start_mode)
 
   close_completion_window()
   apply_highlight()

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -113,7 +113,8 @@ local function set_mode(mode)
   elseif mode == "visual" then
     vim.api.nvim_command("normal! vg_")
   elseif mode == "select" then
-    -- TODO
+    set_mode("visual")
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-g>", true, false, true), "n", true)
   end
 end
 

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -120,13 +120,9 @@ end
 
 ---@param mode dressing.Mode?
 M.restore_mode = function(mode)
-  if mode == "normal" then
+  if mode ~= "insert" then
     vim.cmd("stopinsert")
   end
-
-  -- insert: Nothing to do
-  -- visual: Not supported
-  -- select: Not supported
 end
 
 local function close_completion_window()

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -433,11 +433,6 @@ local show_input = util.make_queued_async_fn(2, function(opts, on_confirm)
 
   local start_mode = config.start_mode
 
-  -- Support start_in_insert for backwards compatibility.
-  if config.start_in_insert ~= nil then
-     start_mode = config.start_in_insert and "insert" or "normal"
-  end
-
   local prompt = opts.prompt or config.default_prompt
   local prompt_lines = vim.split(prompt, "\n", { plain = true, trimempty = true })
 

--- a/lua/dressing/input.lua
+++ b/lua/dressing/input.lua
@@ -122,13 +122,11 @@ end
 local function restore_mode(mode)
   if mode == "normal" then
     vim.cmd("stopinsert")
-  elseif mode == "insert" then
-     -- Nothing to do
-  elseif mode == "visual" then
-     -- Not supported
-  elseif mode == "select" then
-     -- Not supported
   end
+
+  -- insert: Nothing to do
+  -- visual: Not supported
+  -- select: Not supported
 end
 
 local function close_completion_window()
@@ -440,7 +438,7 @@ local show_input = util.make_queued_async_fn(2, function(opts, on_confirm)
   if type(opts) ~= "table" then
     opts = { prompt = tostring(opts) }
   end
-  local config = global_config.get_mod_config("input", opts)  --[[@as dressing.InputConfig]]
+  local config = global_config.get_mod_config("input", opts) --[[@as dressing.InputConfig]]
   if not config.enabled then
     return patch.original_mods.input(opts, on_confirm)
   end

--- a/tests/input_spec.lua
+++ b/tests/input_spec.lua
@@ -1,7 +1,11 @@
 require("plenary.async").tests.add_to_env()
 local dressing = require("dressing")
+local input = require("dressing.input")
 local util = require("tests.util")
+local a = require('plenary.async')
 local channel = a.control.channel
+local assert = require("luassert")
+local stub = require('luassert.stub')
 
 local function run_input(keys, opts)
   opts = opts or {}
@@ -81,50 +85,6 @@ a.describe("input modal", function()
     assert(ret == "", string.format("Got '%s' expected nil", ret))
   end)
 
-  a.it("starts in normal mode when start_mode = 'normal'", function()
-    local orig_cmd = vim.cmd
-    local startinsert_called = false
-    vim.cmd = function(cmd)
-      if cmd == "startinsert!" then
-        startinsert_called = true
-      end
-      orig_cmd(cmd)
-    end
-
-    require("dressing.config").input.start_mode = "normal"
-    run_input({
-      "my text",
-      "<CR>",
-    }, {
-      after_fn = function()
-        vim.cmd = orig_cmd
-      end,
-    })
-    assert(not startinsert_called, "Got 'true' expected 'false'")
-  end)
-
-  a.it("is backwards compatible with start_in_insert = false", function()
-    local orig_cmd = vim.cmd
-    local startinsert_called = false
-    vim.cmd = function(cmd)
-      if cmd == "startinsert!" then
-        startinsert_called = true
-      end
-      orig_cmd(cmd)
-    end
-
-    require("dressing.config").input.start_mode = "normal"
-    run_input({
-      "my text",
-      "<CR>",
-    }, {
-      after_fn = function()
-        vim.cmd = orig_cmd
-      end,
-    })
-    assert(not startinsert_called, "Got 'true' expected 'false'")
-  end)
-
   a.it("queues successive calls to vim.ui.input", function()
     local tx1, rx1 = channel.oneshot()
     local tx2, rx2 = channel.oneshot()
@@ -159,6 +119,74 @@ a.describe("input modal", function()
     })
     assert(ret == "second", string.format("Got '%s' expected 'second'", ret))
     assert(vim.fn.pumvisible() == 0, "Popup menu should not be visible after leaving modal")
+  end)
+
+  local function test_start_mode(expected_start_mode, expected_restore_mode)
+    -- Since going into insert mode does not work well in headless, use mocks.
+    local nvim_get_mode = stub(vim.api, "nvim_get_mode", { mode = expected_restore_mode })
+    local set_mode = stub(input, "set_mode")
+    local restore_mode = stub(input, "restore_mode")
+
+    local tx, rx = channel.oneshot()
+    vim.ui.input({}, tx)
+
+    assert.stub(set_mode).was_called(1)
+    assert.spy(set_mode).was_called_with(expected_start_mode)
+    set_mode:clear()
+    assert.stub(restore_mode).was_not_called()
+
+    util.feedkeys({"<CR>"})
+
+    assert.spy(set_mode).was_not_called()
+    assert.stub(restore_mode).was_called(1)
+    assert.stub(restore_mode).was_called_with(expected_restore_mode)
+
+    rx()
+
+    set_mode:revert()
+    restore_mode:revert()
+    nvim_get_mode:revert()
+  end
+
+  -- Visual causes problems. The other's should be enough. The logic is the same.
+  for _, start_mode in ipairs({ "normal", "insert", "select" }) do
+    -- Only normal and insert are supported.
+    for _, mode_to_restore in ipairs({ "normal", "insert" }) do
+      a.it("sets the mode correctly to start_mode=" .. start_mode .. " restore_mode=" .. mode_to_restore, function()
+        require("dressing.config").input.start_mode = start_mode
+        test_start_mode(start_mode, mode_to_restore)
+      end)
+    end
+  end
+
+  a.it("is backwards compatible with start_in_insert = false", function()
+    require("dressing.config").update({ input = { start_in_insert = false } })
+    test_start_mode("normal", "normal")
+  end)
+
+  a.it("is backwards compatible with start_in_insert = true", function()
+    require("dressing.config").update({ input = { start_in_insert = true } })
+    test_start_mode("insert", "normal")
+  end)
+
+  a.it("get_config takes precedence (normal)", function()
+    require("dressing.config").update({
+      input = {
+        start_mode = "insert",
+        get_config = function() return { start_in_insert = false } end,
+      },
+    })
+    test_start_mode("normal", "normal")
+  end)
+
+  a.it("get_config takes precedence (insert)", function()
+    require("dressing.config").update({
+      input = {
+        start_mode = "normal",
+        get_config = function() return { start_in_insert = true } end,
+      },
+    })
+    test_start_mode("insert", "normal")
   end)
 
   a.it("can cancel out when popup menu is open", function()

--- a/tests/input_spec.lua
+++ b/tests/input_spec.lua
@@ -1,11 +1,11 @@
 require("plenary.async").tests.add_to_env()
+local a = require("plenary.async")
 local dressing = require("dressing")
 local input = require("dressing.input")
 local util = require("tests.util")
-local a = require('plenary.async')
 local channel = a.control.channel
 local assert = require("luassert")
-local stub = require('luassert.stub')
+local stub = require("luassert.stub")
 
 local function run_input(keys, opts)
   opts = opts or {}
@@ -135,7 +135,7 @@ a.describe("input modal", function()
     set_mode:clear()
     assert.stub(restore_mode).was_not_called()
 
-    util.feedkeys({"<CR>"})
+    util.feedkeys({ "<CR>" })
 
     assert.spy(set_mode).was_not_called()
     assert.stub(restore_mode).was_called(1)
@@ -152,10 +152,16 @@ a.describe("input modal", function()
   for _, start_mode in ipairs({ "normal", "insert", "select" }) do
     -- Only normal and insert are supported.
     for _, mode_to_restore in ipairs({ "normal", "insert" }) do
-      a.it("sets the mode correctly to start_mode=" .. start_mode .. " restore_mode=" .. mode_to_restore, function()
-        require("dressing.config").input.start_mode = start_mode
-        test_start_mode(start_mode, mode_to_restore)
-      end)
+      a.it(
+        "sets the mode correctly to start_mode="
+          .. start_mode
+          .. " restore_mode="
+          .. mode_to_restore,
+        function()
+          require("dressing.config").input.start_mode = start_mode
+          test_start_mode(start_mode, mode_to_restore)
+        end
+      )
     end
   end
 
@@ -173,7 +179,9 @@ a.describe("input modal", function()
     require("dressing.config").update({
       input = {
         start_mode = "insert",
-        get_config = function() return { start_in_insert = false } end,
+        get_config = function()
+          return { start_in_insert = false }
+        end,
       },
     })
     test_start_mode("normal", "normal")
@@ -183,7 +191,9 @@ a.describe("input modal", function()
     require("dressing.config").update({
       input = {
         start_mode = "normal",
-        get_config = function() return { start_in_insert = true } end,
+        get_config = function()
+          return { start_in_insert = true }
+        end,
       },
     })
     test_start_mode("insert", "normal")

--- a/tests/input_spec.lua
+++ b/tests/input_spec.lua
@@ -81,7 +81,7 @@ a.describe("input modal", function()
     assert(ret == "", string.format("Got '%s' expected nil", ret))
   end)
 
-  a.it("starts in normal mode when start_in_insert = false", function()
+  a.it("starts in normal mode when start_mode = 'normal'", function()
     local orig_cmd = vim.cmd
     local startinsert_called = false
     vim.cmd = function(cmd)
@@ -91,7 +91,29 @@ a.describe("input modal", function()
       orig_cmd(cmd)
     end
 
-    require("dressing.config").input.start_in_insert = false
+    require("dressing.config").input.start_mode = "normal"
+    run_input({
+      "my text",
+      "<CR>",
+    }, {
+      after_fn = function()
+        vim.cmd = orig_cmd
+      end,
+    })
+    assert(not startinsert_called, "Got 'true' expected 'false'")
+  end)
+
+  a.it("is backwards compatible with start_in_insert = false", function()
+    local orig_cmd = vim.cmd
+    local startinsert_called = false
+    vim.cmd = function(cmd)
+      if cmd == "startinsert!" then
+        startinsert_called = true
+      end
+      orig_cmd(cmd)
+    end
+
+    require("dressing.config").input.start_mode = "normal"
     run_input({
       "my text",
       "<CR>",


### PR DESCRIPTION
Implement `start_mode`. It's like `start_in_insert`, but more flexible.

## Context

Implement #174 

## Description

I added `start_mode`. I kept `start_in_insert` for backwards compatibility.

## Test Plan

I tried each value of `start_mode` with a default value and without. I also added automated tests of the backwards compatibility of `start_in_insert`.
