### PR TITLE
fix(apply_shim): add nil check for opts

### DIFF
--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -165,11 +165,11 @@ local M = vim.deepcopy(default_config)
 
 -- Apply shims for backwards compatibility
 ---@param key string
----@param opts table
----@return table
+---@param opts? table
+---@return table?
 M.apply_shim = function(key, opts)
   -- Support start_in_insert for backwards compatibility.
-  if key == "input" and opts.start_in_insert ~= nil then
+  if key == "input" and opts ~= nil and opts.start_in_insert ~= nil then
     opts.start_mode = opts.start_in_insert and "insert" or "normal"
   end
 


### PR DESCRIPTION
#175 does not check for possible nil value of `opts` on `add_shim` (that may come from `:h dressing_get_config()`). Add `nil` check

## Context

#175 added `apply_shim` to maintain backwards compatibility, but it doesn't check if `opts` is `nil` before trying to access it. It may be `nil` since `:h dressing_get_config()` allows for a `nil` return value.

## Description

A `nil` check is added

## Test Plan

My config was broken after #175 since I have the following on my oil setup.

```lua
{
  -- ...
  input = {
    get_config = function(opts)
      if opts.prompt == "cmd: " then
        return {
          -- some custom options
        }
      end
    end,
  },
  -- ...
}
```

The function returns `nil` to fallback to the default config whe prompt is not `cmd: `. With this config, calling `vim.ui.input({}, function() end)` resulted in an error before this PR and works as expected after it. 