### PR TITLE
fix(select-builtin): disable highlighting of `[n]` due to MatchParen

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ require("dressing").setup({
       win_options = {
         cursorline = true,
         cursorlineopt = "both",
+        -- disable highlighting for the brackets around the numbers
+        winhighlight = "MatchParen:",
       },
 
       -- These can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -127,6 +127,8 @@ local default_config = {
       win_options = {
         cursorline = true,
         cursorlineopt = "both",
+        -- disable highlighting for the brackets around the numbers
+        winhighlight = "MatchParen:",
       },
 
       -- These can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)


### PR DESCRIPTION
Disable highlighting of numbers in the `builtin` DressingSelect. (The numbers that are displayed when `show_numbers = true`).

## Context

before:
![Pasted image 2024-11-13 at 14 16 40@2x](https://github.com/user-attachments/assets/45bf9311-6c2a-4ac8-92b9-a6d2174b97af)

after:
![Pasted image 2024-11-13 at 14 15 47@2x](https://github.com/user-attachments/assets/abb91464-993e-4ecc-b231-89bbdab4f732)

_What is the problem you are trying to solve?_
Only a minor aesthetic one. The highlight of matching parentheses is not useful in the selection window.

