### PR TITLE
fix(input): add padding to left border (fixes #184)

### DIFF
--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -129,6 +129,8 @@ local default_config = {
         cursorlineopt = "both",
         -- disable highlighting for the brackets around the numbers
         winhighlight = "MatchParen:",
+        -- adds padding at the left border
+        statuscolumn = " ",
       },
 
       -- These can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)


### PR DESCRIPTION
add padding to left border

## Context
_If related to an issue, please link it here. You may omit some background
details if it is in the issue._
see #184

## Description
_Describe how the changes add the functionality or fix the issue under "Context"_
uses `statuscolumn = " "` to add padding that does not interfere with the cursor.
