### PR TITLE
feat(snipe): add snipe select backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ require("dressing").setup({
     enabled = true,
 
     -- Priority list of preferred vim.select implementations
-    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui" },
+    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui", "snipe" },
 
     -- Trim trailing `:` from prompt
     trim_prompt = true,
@@ -241,6 +241,19 @@ require("dressing").setup({
       max_height = 40,
       min_width = 40,
       min_height = 10,
+    },
+
+    -- Options for snipe selector
+    snipe = {
+      -- Default options come from your snipe.nvim configuration,
+      -- but you can override them here.
+      -- See available options for snipe.menu in the snipe.nvim repository
+      options = {},
+
+      --- Callback function that runs when a new snipe buffer is created
+      --- Useful to override the default keymaps logic
+      --- @type fun(menu: table, on_choice: fun(item: any, idx: number|nil))
+      add_new_buffer_callback = nil,
     },
 
     -- Options for built-in selector

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -67,7 +67,7 @@ local default_config = {
     enabled = true,
 
     -- Priority list of preferred vim.select implementations
-    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui" },
+    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui", "snipe" },
 
     -- Trim trailing `:` from prompt
     trim_prompt = true,
@@ -112,6 +112,19 @@ local default_config = {
       max_height = 40,
       min_width = 40,
       min_height = 10,
+    },
+
+    -- Options for snipe selector
+    snipe = {
+      -- Default options come from your snipe.nvim configuration,
+      -- but you can override them here.
+      -- See available options for snipe.menu in the snipe.nvim repository
+      options = {},
+
+      --- Callback function that runs when a new snipe buffer is created
+      --- Useful to override the default keymaps logic
+      --- @type fun(menu: table, on_choice: fun(item: any, idx: number|nil))
+      add_new_buffer_callback = nil,
     },
 
     -- Options for built-in selector

--- a/lua/dressing/select/snipe.lua
+++ b/lua/dressing/select/snipe.lua
@@ -1,0 +1,56 @@
+local M = {}
+
+local snipe = require("snipe")
+
+M.is_supported = function()
+  return pcall(require, "snipe")
+end
+
+M._init_snipe_menu = function(config, on_choice)
+  config = config or {}
+
+  local default_opts = {
+    default_keymaps = {
+      auto_setup = true,
+    },
+  }
+
+  local opts = vim.tbl_deep_extend("keep", default_opts, config.options or {})
+
+  local snipe_menu = require("snipe.menu"):new(opts)
+
+  -- Run user callback if provided
+  if config.add_new_buffer_callback then
+    snipe_menu:add_new_buffer_callback(function(m)
+      config.add_new_buffer_callback(m, on_choice)
+    end)
+  end
+
+  snipe.ui_select_menu = snipe_menu
+end
+
+M.select = function(config, items, opts, on_choice)
+  -- Ensure the snipe menu is initialized
+  -- It is enough to initialize once
+  if not snipe.ui_select_menu then
+    M._init_snipe_menu(config, on_choice)
+  end
+
+  snipe.ui_select(items, opts, on_choice)
+  snipe.ui_select_menu.page = 1
+  -- Set cursor to the first item
+  vim.api.nvim_win_set_cursor(snipe.ui_select_menu.win, { 1, 0 })
+
+  vim.api.nvim_create_autocmd("BufLeave", {
+    desc = "Cancel vim.ui.select",
+    once = true,
+    callback = function()
+      on_choice(nil, nil)
+      snipe.ui_select_menu:close()
+      -- Reset the title to avoid the title being set for the next menu
+      snipe.ui_select_menu.config.open_win_override.title = nil
+    end,
+  })
+end
+
+return M


### PR DESCRIPTION
add [snipe](https://github.com/leath-dub/snipe.nvim) select backend

## Description

Snipe can be used as vim.ui.select, an example is given in the [snipe documentation](https://github.com/leath-dub/snipe.nvim?tab=readme-ov-file#use-snipe-as-a-vimuiselect-wrapper)