### PR TITLE
feat(select): add snacks_picker backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Neovim 0.8.0+ (for earlier versions, use the [nvim-0.7](https://github.com/steve
 
 `vim.select` (snacks_picker)
 
-![Screenshot from 2025-01-29 03-08-00](https://github.com/user-attachments/assets/8e2ab738-f7eb-44e9-b161-dcab2251120b)
+![Screenshot from 2025-01-29 03-08-00](https://github.com/user-attachments/assets/4bc72539-9c81-4428-8778-f7904a16898c)
 
 `vim.select` (built-in)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Neovim 0.8.0+ (for earlier versions, use the [nvim-0.7](https://github.com/steve
 
 ![Screenshot from 2021-12-02 19-47-56](https://user-images.githubusercontent.com/506791/144542071-1aa66f81-b07c-492e-9884-fdafed1006df.png)
 
+`vim.select` (snacks_picker)
+
+![Screenshot from 2025-01-29 03-08-00](https://github.com/user-attachments/assets/8e2ab738-f7eb-44e9-b161-dcab2251120b)
+
 `vim.select` (built-in)
 
 ![Screenshot from 2021-12-04 17-14-32](https://user-images.githubusercontent.com/506791/144729527-ede0d7ba-a6e6-41e0-be5a-1a5f16d35b05.png)
@@ -196,7 +200,7 @@ require("dressing").setup({
     enabled = true,
 
     -- Priority list of preferred vim.select implementations
-    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui" },
+    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui", "snacks_picker" },
 
     -- Trim trailing `:` from prompt
     trim_prompt = true,

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -67,7 +67,7 @@ local default_config = {
     enabled = true,
 
     -- Priority list of preferred vim.select implementations
-    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui", "snacks_picker" },
+    backend = { "snacks_picker", "telescope", "fzf_lua", "fzf", "builtin", "nui" },
 
     -- Trim trailing `:` from prompt
     trim_prompt = true,

--- a/lua/dressing/config.lua
+++ b/lua/dressing/config.lua
@@ -67,7 +67,7 @@ local default_config = {
     enabled = true,
 
     -- Priority list of preferred vim.select implementations
-    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui" },
+    backend = { "telescope", "fzf_lua", "fzf", "builtin", "nui", "snacks_picker" },
 
     -- Trim trailing `:` from prompt
     trim_prompt = true,

--- a/lua/dressing/select/snacks_picker.lua
+++ b/lua/dressing/select/snacks_picker.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.is_supported = function()
+  return pcall(require, "snacks.picker")
+end
+
+M.select = function(_, items, opts, on_choice)
+  return require("snacks.picker.select").select(items, opts, on_choice)
+end
+
+return M


### PR DESCRIPTION
Adds the
[snacks picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) backend option.

## Context

Like telescope and fzf-lua, it already provides it's own override for `vim.ui.select`, BUT since plugins like avante rely on using dressing.nvim for picking files and such, having a backend that can fuzzy find is more convenient than the builtin.

## Test Plan

To setup:

```lua
require("dressing").setup({ select = { enabled = true, backend = "snacks_picker" }})
```

Or using lazy.nvim:

```lua
{
  "stevearc/dressing.nvim",
  opts = {
    select = { enabled = true, backend = "snacks_picker" },
  },
}
```

And then run something like:

`:lua vim.ui.select({ "Yes", "No" }, { prompt = "Hello, World!" }, function() end)`